### PR TITLE
fix problem when create_jp2 raised an error

### DIFF
--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -129,7 +129,8 @@ module Assembly
                       @path
                     end
 
-      result = `#{jp2_create_command(source_path: source_path, output: output)}`
+      jp2_command = jp2_create_command(source_path: source_path, output: output)
+      result = `#{jp2_command}`
       raise "JP2 creation command failed: #{jp2_command} with result #{result}" unless $CHILD_STATUS.success?
 
       File.delete(source_path) unless @tmp_path.nil? || params[:preserve_tmp_source]


### PR DESCRIPTION
it is useful to see the jp2_command that caused the problem, fix the problem so it shows again when raising errors (it used to, but a refactor broke this)