### PR TITLE
Add throttling to convert and kdu_compress.

### DIFF
--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -181,6 +181,7 @@ module Assembly
     # rubocop:disable Metrics/MethodLength
     def kdu_compress_default_options
       [
+        '-num_threads 2', # forces Kakadu to only use 2 threads
         '-precise', # forces the use of 32-bit representations
         '-no_weights', # minimization of the MSE over all reconstructed colour components
         '-quiet', # suppress informative messages.
@@ -269,6 +270,10 @@ module Assembly
       tmp_path = tmp_tiff_file.path
 
       options = []
+
+      # Limit the amount of memory ImageMagick is able to use.
+      options << '-limit memory 1GiB -limit map 1GiB'
+
       case samples_per_pixel
       when 3
         options << '-type TrueColor'

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -75,7 +75,7 @@ describe Assembly::Image do
     #  of supplied image components and/or colour palette.  You can address this
     #  problem by supplying a `-jp2_space' or `-jpx_space' argument to explicitly
     #  identify a colour space that has anywhere from 1 to 1 colour components.
-    generate_test_image(TEST_TIF_INPUT_FILE, color: 'white', image_type: 'Bilevel')
+    generate_test_image(TEST_TIF_INPUT_FILE, image_type: 'Bilevel')
     expect(File).to exist TEST_TIF_INPUT_FILE
     expect(File).to_not exist TEST_JP2_OUTPUT_FILE
     @ai = Assembly::Image.new(TEST_TIF_INPUT_FILE)
@@ -88,7 +88,7 @@ describe Assembly::Image do
   end
 
   it 'creates color jp2 when given a color tif but bitonal image data (1 channels and 1 bits per pixel)' do
-    generate_test_image(TEST_TIF_INPUT_FILE, color: 'white', image_type: 'TrueColor', profile: '')
+    generate_test_image(TEST_TIF_INPUT_FILE, color: 'Bilevel', image_type: 'TrueColor', profile: '')
     expect(File).to exist TEST_TIF_INPUT_FILE
     expect(File).to_not exist TEST_JP2_OUTPUT_FILE
     @ai = Assembly::Image.new(TEST_TIF_INPUT_FILE)
@@ -101,7 +101,7 @@ describe Assembly::Image do
   end
 
   it 'creates grayscale jp2 when given a graycale tif but with bitonal image data (1 channel and 1 bits per pixel)' do
-    generate_test_image(TEST_TIF_INPUT_FILE, color: 'white', image_type: 'Grayscale', profile: '')
+    generate_test_image(TEST_TIF_INPUT_FILE, color: 'Bilevel', image_type: 'Grayscale', profile: '')
     expect(File).to exist TEST_TIF_INPUT_FILE
     expect(File).to_not exist TEST_JP2_OUTPUT_FILE
     @ai = Assembly::Image.new(TEST_TIF_INPUT_FILE)
@@ -114,7 +114,7 @@ describe Assembly::Image do
   end
 
   it 'creates color jp2 when given a color tif but with greyscale image data (1 channel and 8 bits per pixel)' do
-    generate_test_image(TEST_TIF_INPUT_FILE, color: 'gray', image_type: 'TrueColor', profile: '')
+    generate_test_image(TEST_TIF_INPUT_FILE, color: 'Grayscale', image_type: 'TrueColor', profile: '')
     expect(File).to exist TEST_TIF_INPUT_FILE
     expect(File).to_not exist TEST_JP2_OUTPUT_FILE
     @ai = Assembly::Image.new(TEST_TIF_INPUT_FILE)
@@ -157,8 +157,17 @@ describe Assembly::Image do
   end
 
   it 'does not run if the input file is a jp2' do
-    generate_test_image(TEST_JP2_OUTPUT_FILE)
-    expect(File).to exist TEST_JP2_OUTPUT_FILE
+    generate_test_image(TEST_TIF_INPUT_FILE, profile: '') # generate a test input with no profile
+    expect(File).to exist TEST_TIF_INPUT_FILE
+    expect(File).to_not exist TEST_JP2_OUTPUT_FILE
+    @ai = Assembly::Image.new(TEST_TIF_INPUT_FILE)
+    # Indicates a temp tiff was not created.
+    expect(@ai.tmp_path).to be_nil
+    expect(@ai).to_not have_color_profile
+    expect(@ai).to be_a_valid_image
+    expect(@ai).to be_jp2able
+    @ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+    expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
     @ai = Assembly::Image.new(TEST_JP2_OUTPUT_FILE)
     expect(@ai).to be_valid_image
     expect(@ai).to_not be_jp2able

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,10 +17,10 @@ TEST_DRUID           = 'nx288wh8889'
 # rubocop:disable Metrics/CyclomaticComplexity
 # rubocop:disable Metrics/MethodLength
 def generate_test_image(file, params = {})
-  color = params[:color] || 'red'
+  color = params[:color] || 'TrueColor'
   profile = params[:profile] || 'sRGBIEC6196621'
   image_type = params[:image_type]
-  create_command = "convert -size 100x100 xc:#{color} "
+  create_command = "convert rose: -scale 100x100\! -type #{color} "
   create_command += ' -profile ' + File.join(Assembly::PATH_TO_IMAGE_GEM, 'profiles', profile + '.icc') + ' ' unless profile == ''
   create_command += " -type #{image_type} " if image_type
   create_command += ' -compress lzw ' if params[:compress]


### PR DESCRIPTION
This will limit the amount of memory used by ImageMagick and the number of threads that kdu_compress will need. This change is regarding https://github.com/sul-dlss/assembly-image/issues/21