### PR TITLE
[refactor] Extract Jp2Creator class

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require: rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 3.0
+  SuggestExtensions: false
 
 # rspec expect{...} is conventional
 Layout/SpaceBeforeBlockBraces:

--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -1,18 +1,13 @@
 # frozen_string_literal: true
 
 require 'assembly-objectfile'
-require 'tempfile'
-require 'English' # see https://github.com/rubocop-hq/rubocop/issues/1747 (not #MAGA related)
+require_relative 'jp2_creator'
 
 module Assembly
   # The Image class contains methods to operate on an image.
-  # rubocop:disable Metrics/ClassLength
   class Image
     # include common behaviors from assembly-objectfile gem
     include Assembly::ObjectFileable
-
-    # stores the path to the tmp file generated during the JP2 creation process
-    attr_accessor :tmp_path
 
     # Examines the input image for validity.  Used to determine if image is correct and if JP2 generation is likely to succeed.
     #  This method is automatically called before you create a jp2 but it can be called separately earlier as a sanity check.
@@ -99,7 +94,7 @@ module Assembly
     #   source_img=Assembly::Image.new('/input/path_to_file.tif')
     #   puts source_img.jp2_filename # gives /input/path_to_file.jp2
     def jp2_filename
-      File.extname(@path).empty? ? "#{@path}.jp2" : @path.gsub(File.extname(@path), '.jp2')
+      File.extname(path).empty? ? "#{path}.jp2" : path.gsub(File.extname(path), '.jp2')
     end
 
     # Returns the full DPG equivalent jp2 path and filename that would match with the given image
@@ -130,64 +125,8 @@ module Assembly
     #   puts derivative_image.path # '/input/path_to_file.jp2'
     # rubocop:disable Metrics/CyclomaticComplexity:
     def create_jp2(params = {})
-      output = params[:output] || jp2_filename
-      create_jp2_checks(output: output, overwrite: params[:overwrite])
-
-      # Using instance variable so that can check in tests.
-      @tmp_path = make_tmp_tiff(tmp_folder: params[:tmp_folder])
-
-      jp2_command = jp2_create_command(source_path: @tmp_path, output: output)
-      result = `#{jp2_command}`
-      raise "JP2 creation command failed: #{jp2_command} with result #{result}" unless $CHILD_STATUS.success?
-
-      File.delete(@tmp_path) unless @tmp_path.nil? || params[:preserve_tmp_source]
-
-      # create output response object, which is an Assembly::Image type object
-      Assembly::Image.new(output)
+      Jp2Creator.create(self, params)
     end
-
-    private
-
-    # def create_temp_tiff?
-    #   mimetype != 'image/tiff' || compressed?
-    # end
-
-    def create_jp2_checks(output:, overwrite:)
-      check_for_file
-      raise 'input file is not a valid image, or is the wrong mimetype' unless jp2able?
-
-      raise SecurityError, "output #{output} exists, cannot overwrite" if !overwrite && File.exist?(output)
-      raise SecurityError, 'cannot recreate jp2 over itself' if overwrite && mimetype == 'image/jp2' && output == @path
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
-
-    def jp2_create_command(source_path:, output:)
-      kdu_bin = 'kdu_compress'
-      options = []
-      options << '-jp2_space sRGB' if samples_per_pixel == 3
-      options += kdu_compress_default_options
-      options << "Clayers=#{layers}"
-      "#{kdu_bin} #{options.join(' ')} -i '#{source_path}' -o '#{output}' 2>&1"
-    end
-
-    # rubocop:disable Metrics/MethodLength
-    def kdu_compress_default_options
-      [
-        '-num_threads 2', # forces Kakadu to only use 2 threads
-        '-precise', # forces the use of 32-bit representations
-        '-no_weights', # minimization of the MSE over all reconstructed colour components
-        '-quiet', # suppress informative messages.
-        'Creversible=no', # Disable reversible compression
-        'Cmodes=BYPASS', #
-        'Corder=RPCL', # R=resolution P=position C=component L=layer
-        'Cblk=\\{64,64\\}', # code-block dimensions; 64x64 happens to also be the default
-        'Cprecincts=\\{256,256\\},\\{256,256\\},\\{128,128\\}', # Precinct dimensions; 256x256 for the 2 highest resolution levels, defaults to 128x128 for the rest
-        'ORGgen_plt=yes', # Insert packet length information
-        '-rate 1.5', # Ratio of compressed bits to the image size
-        'Clevels=5' # Number of wavelet decomposition levels, or stages
-      ]
-    end
-    # rubocop:enable Metrics/MethodLength
 
     def samples_per_pixel
       if exif['samplesperpixel']
@@ -202,6 +141,14 @@ module Assembly
       end
     end
 
+    # Get size of image data in bytes
+    def image_data_size
+      (samples_per_pixel * height * width * bits_per_sample) / 8
+    end
+
+    private
+
+    # rubocop:enable Metrics/CyclomaticComplexity
     def bits_per_sample
       if exif['bitspersample']
         exif['bitspersample'].to_i
@@ -212,96 +159,5 @@ module Assembly
         end
       end
     end
-
-    # Get size of image data in bytes
-    def image_data_size
-      (samples_per_pixel * height * width * bits_per_sample) / 8
-    end
-
-    # Bigtiff needs to be used if size of image exceeds 2^32 bytes.
-    def need_bigtiff?
-      image_data_size >= 2**32
-    end
-
-    # Get the number of JP2 layers to generate
-    def layers
-      pixdem = [width, height].max
-      ((Math.log(pixdem) / Math.log(2)) - (Math.log(96) / Math.log(2))).ceil + 1
-    end
-
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    def profile_conversion_switch(profile, tmp_folder:)
-      path_to_profiles = File.join(Assembly::PATH_TO_IMAGE_GEM, 'profiles')
-      # eventually we may allow the user to specify the output_profile...when we do, you can just uncomment this code
-      # and update the tests that check for this
-      output_profile = 'sRGBIEC6196621' # params[:output_profile] || 'sRGBIEC6196621'
-      output_profile_file = File.join(path_to_profiles, "#{output_profile}.icc")
-
-      raise "output profile #{output_profile} invalid" unless File.exist?(output_profile_file)
-
-      return '' if profile.nil?
-
-      # if the input color profile exists, contract paths to the profile and setup the command
-
-      input_profile = profile.gsub(/[^[:alnum:]]/, '') # remove all non alpha-numeric characters, so we can get to a filename
-
-      # construct a path to the input profile, which might exist either in the gem itself or in the tmp folder
-      input_profile_file_gem = File.join(path_to_profiles, "#{input_profile}.icc")
-      input_profile_file_tmp = File.join(tmp_folder, "#{input_profile}.icc")
-      input_profile_file = File.exist?(input_profile_file_gem) ? input_profile_file_gem : input_profile_file_tmp
-
-      # if input profile was extracted and does not matches an existing known profile either in the gem or in the tmp folder,
-      # we'll issue an imagicmagick command to extract the profile to the tmp folder
-      unless File.exist?(input_profile_file)
-        input_profile_extract_command = "MAGICK_TEMPORARY_PATH=#{tmp_folder} convert '#{@path}'[0] #{input_profile_file}" # extract profile from input image
-        result = `#{input_profile_extract_command} 2>&1`
-        raise "input profile extraction command failed: #{input_profile_extract_command} with result #{result}" unless $CHILD_STATUS.success?
-        # if extraction failed or we cannot write the file, throw exception
-        raise 'input profile is not a known profile and could not be extracted from input file' unless File.exist?(input_profile_file)
-      end
-
-      "-profile #{input_profile_file} -profile #{output_profile_file}"
-    end
-
-    def make_tmp_tiff(tmp_folder: nil)
-      tmp_folder ||= Dir.tmpdir
-      raise "tmp_folder #{tmp_folder} does not exists" unless File.exist?(tmp_folder)
-
-      # make temp tiff filename
-      tmp_tiff_file = Tempfile.new(['assembly-image', '.tif'], tmp_folder)
-      tmp_path = tmp_tiff_file.path
-
-      options = []
-
-      # Limit the amount of memory ImageMagick is able to use.
-      options << '-limit memory 1GiB -limit map 1GiB'
-
-      case samples_per_pixel
-      when 3
-        options << '-type TrueColor'
-      when 1
-        options << '-depth 8' # force the production of a grayscale access derivative
-        options << '-type Grayscale'
-      end
-
-      options << profile_conversion_switch(profile, tmp_folder: tmp_folder)
-
-      # The output in the covnert command needs to be prefixed by the image type. By default ImageMagick
-      # will assume TIFF: when the file extension is .tif/.tiff. TIFF64: Needs to be forced when image will
-      # exceed 2^32 bytes in size
-      tiff_type = need_bigtiff? ? 'TIFF64:' : ''
-
-      tiff_command = "MAGICK_TEMPORARY_PATH=#{tmp_folder} convert -quiet -compress none #{options.join(' ')} '#{@path}[0]' #{tiff_type}'#{tmp_path}'"
-      result = `#{tiff_command} 2>&1`
-      raise "tiff convert command failed: #{tiff_command} with result #{result}" unless $CHILD_STATUS.success?
-
-      tmp_path
-    end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/lib/assembly-image/jp2_creator.rb
+++ b/lib/assembly-image/jp2_creator.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require 'tempfile'
+require 'English' # see https://github.com/rubocop-hq/rubocop/issues/1747 (not #MAGA related)
+
+module Assembly
+  class Image
+    # Creates jp2 derivatives
+    class Jp2Creator # rubocop:disable  Metrics/ClassLength
+      # Create a JP2 file for the current image.
+      # Important note: this will not work for multipage TIFFs.
+      #
+      # @return [Assembly::Image] object containing the generated JP2 file
+      #
+      # @param [Assembly::Image] the image file
+      # @param [Hash] params Optional parameters specified as a hash, using symbols for options:
+      #   * :output => path to the output JP2 file (default: mirrors the source file name and path, but with a .jp2 extension)
+      #   * :overwrite => if set to false, an existing JP2 file with the same name won't be overwritten (default: false)
+      #   * :tmp_folder =>  the temporary folder to use when creating the jp2 (default: '/tmp'); also used by imagemagick
+      #   * :preserve_tmp_source => if set to true, preserve the temporary file generated during the creation process and store path in 'tmp_path' attribute (default: false)
+      #
+      # Example:
+      #   source_img = Assembly::Image.new('/input/path_to_file.tif')
+      #   derivative_img = source_img.create_jp2(:overwrite=>true)
+      #   puts derivative_img.mimetype # 'image/jp2'
+      #   puts derivative_image.path # '/input/path_to_file.jp2'
+      def self.create(image, params = {})
+        new(image, params).create
+      end
+
+      def initialize(image, params)
+        @image = image
+        @output_path = params.fetch(:output, image.jp2_filename)
+        @tmp_folder = params[:tmp_folder]
+        @preserve_tmp_source = params[:preserve_tmp_source]
+        @overwrite = params[:overwrite]
+        @params = params
+      end
+
+      attr_reader :image, :output_path, :tmp_folder, :tmp_path
+
+      # @return [Assembly::Image] object containing the generated JP2 file
+      def create
+        create_jp2_checks
+
+        # Using instance variable so that can check in tests.
+        @tmp_path = make_tmp_tiff(tmp_folder: tmp_folder)
+
+        jp2_command = jp2_create_command(source_path: @tmp_path, output: output_path)
+        result = `#{jp2_command}`
+        raise "JP2 creation command failed: #{jp2_command} with result #{result}" unless $CHILD_STATUS.success?
+
+        File.delete(@tmp_path) unless @tmp_path.nil? || preserve_tmp_source?
+
+        # create output response object, which is an Assembly::Image type object
+        Image.new(output_path)
+      end
+
+      private
+
+      def preserve_tmp_source?
+        @preserve_tmp_source
+      end
+
+      def overwrite?
+        @overwrite
+      end
+
+      def jp2_create_command(source_path:, output:)
+        options = []
+        options << '-jp2_space sRGB' if image.samples_per_pixel == 3
+        options += KDU_COMPRESS_DEFAULT_OPTIONS
+        options << "Clayers=#{layers}"
+        "kdu_compress #{options.join(' ')} -i '#{source_path}' -o '#{output}' 2>&1"
+      end
+
+      # Get the number of JP2 layers to generate
+      def layers
+        pixdem = [image.width, image.height].max
+        ((Math.log(pixdem) / Math.log(2)) - (Math.log(96) / Math.log(2))).ceil + 1
+      end
+
+      KDU_COMPRESS_DEFAULT_OPTIONS = [
+        '-num_threads 2', # forces Kakadu to only use 2 threads
+        '-precise', # forces the use of 32-bit representations
+        '-no_weights', # minimization of the MSE over all reconstructed colour components
+        '-quiet', # suppress informative messages.
+        'Creversible=no', # Disable reversible compression
+        'Cmodes=BYPASS', #
+        'Corder=RPCL', # R=resolution P=position C=component L=layer
+        'Cblk=\\{64,64\\}', # code-block dimensions; 64x64 happens to also be the default
+        'Cprecincts=\\{256,256\\},\\{256,256\\},\\{128,128\\}', # Precinct dimensions; 256x256 for the 2 highest resolution levels, defaults to 128x128 for the rest
+        'ORGgen_plt=yes', # Insert packet length information
+        '-rate 1.5', # Ratio of compressed bits to the image size
+        'Clevels=5' # Number of wavelet decomposition levels, or stages
+      ].freeze
+
+      # rubocop:disable Metrics/AbcSize
+      def create_jp2_checks
+        image.send(:check_for_file)
+        raise 'input file is not a valid image, or is the wrong mimetype' unless image.jp2able?
+
+        raise SecurityError, "output #{output_path} exists, cannot overwrite" if !overwrite? && File.exist?(output_path)
+        raise SecurityError, 'cannot recreate jp2 over itself' if overwrite? && image.mimetype == 'image/jp2' && output_path == image.path
+      end
+
+      # rubocop:disable Metrics/MethodLength
+      def profile_conversion_switch(profile, tmp_folder:)
+        path_to_profiles = File.join(Assembly::PATH_TO_IMAGE_GEM, 'profiles')
+        # eventually we may allow the user to specify the output_profile...when we do, you can just uncomment this code
+        # and update the tests that check for this
+        output_profile = 'sRGBIEC6196621' # params[:output_profile] || 'sRGBIEC6196621'
+        output_profile_file = File.join(path_to_profiles, "#{output_profile}.icc")
+
+        raise "output profile #{output_profile} invalid" unless File.exist?(output_profile_file)
+
+        return '' if image.profile.nil?
+
+        # if the input color profile exists, contract paths to the profile and setup the command
+
+        input_profile = profile.gsub(/[^[:alnum:]]/, '') # remove all non alpha-numeric characters, so we can get to a filename
+
+        # construct a path to the input profile, which might exist either in the gem itself or in the tmp folder
+        input_profile_file_gem = File.join(path_to_profiles, "#{input_profile}.icc")
+        input_profile_file_tmp = File.join(tmp_folder, "#{input_profile}.icc")
+        input_profile_file = File.exist?(input_profile_file_gem) ? input_profile_file_gem : input_profile_file_tmp
+
+        # if input profile was extracted and does not matches an existing known profile either in the gem or in the tmp folder,
+        # we'll issue an imagicmagick command to extract the profile to the tmp folder
+        unless File.exist?(input_profile_file)
+          input_profile_extract_command = "MAGICK_TEMPORARY_PATH=#{tmp_folder} convert '#{image.path}'[0] #{input_profile_file}" # extract profile from input image
+          result = `#{input_profile_extract_command} 2>&1`
+          raise "input profile extraction command failed: #{input_profile_extract_command} with result #{result}" unless $CHILD_STATUS.success?
+          # if extraction failed or we cannot write the file, throw exception
+          raise 'input profile is not a known profile and could not be extracted from input file' unless File.exist?(input_profile_file)
+        end
+
+        "-profile #{input_profile_file} -profile #{output_profile_file}"
+      end
+
+      # Bigtiff needs to be used if size of image exceeds 2^32 bytes.
+      def need_bigtiff?
+        image.image_data_size >= 2**32
+      end
+
+      def make_tmp_tiff(tmp_folder: nil)
+        tmp_folder ||= Dir.tmpdir
+        raise "tmp_folder #{tmp_folder} does not exists" unless File.exist?(tmp_folder)
+
+        # make temp tiff filename
+        tmp_tiff_file = Tempfile.new(['assembly-image', '.tif'], tmp_folder)
+        tmp_path = tmp_tiff_file.path
+
+        options = []
+
+        # Limit the amount of memory ImageMagick is able to use.
+        options << '-limit memory 1GiB -limit map 1GiB'
+
+        case image.samples_per_pixel
+        when 3
+          options << '-type TrueColor'
+        when 1
+          options << '-depth 8' # force the production of a grayscale access derivative
+          options << '-type Grayscale'
+        end
+
+        options << profile_conversion_switch(image.profile, tmp_folder: tmp_folder)
+
+        # The output in the covnert command needs to be prefixed by the image type. By default ImageMagick
+        # will assume TIFF: when the file extension is .tif/.tiff. TIFF64: Needs to be forced when image will
+        # exceed 2^32 bytes in size
+        tiff_type = need_bigtiff? ? 'TIFF64:' : ''
+
+        tiff_command = "MAGICK_TEMPORARY_PATH=#{tmp_folder} convert -quiet -compress none #{options.join(' ')} '#{image.path}[0]' #{tiff_type}'#{tmp_path}'"
+        result = `#{tiff_command} 2>&1`
+        raise "tiff convert command failed: #{tiff_command} with result #{result}" unless $CHILD_STATUS.success?
+
+        tmp_path
+      end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
+    end
+  end
+end

--- a/spec/assembly/image/jp2_creator_spec.rb
+++ b/spec/assembly/image/jp2_creator_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Assembly::Image::Jp2Creator do
+  subject(:result) { creator.create }
+
+  let(:ai) { Assembly::Image.new(input_path) }
+  let(:input_path) { TEST_TIF_INPUT_FILE }
+  let(:creator) { described_class.new(ai, output: TEST_JP2_OUTPUT_FILE) }
+
+  after do
+    # after each test, empty out the input and output test directories
+    remove_files(TEST_INPUT_DIR)
+    remove_files(TEST_OUTPUT_DIR)
+  end
+
+  context 'when given an LZW compressed RGB tif' do
+    before do
+      generate_test_image(TEST_TIF_INPUT_FILE, compress: 'lzw')
+    end
+
+    it 'creates the jp2 with a temp file' do
+      expect(File).to exist TEST_TIF_INPUT_FILE
+      expect(File).not_to exist TEST_JP2_OUTPUT_FILE
+      expect(result).to be_a_kind_of Assembly::Image
+      expect(result.path).to eq TEST_JP2_OUTPUT_FILE
+      expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
+
+      # Indicates a temp tiff was not created.
+      expect(creator.tmp_path).not_to be_nil
+      expect(result.exif.colorspace).to eq 'sRGB'
+      jp2 = Assembly::Image.new(TEST_JP2_OUTPUT_FILE)
+      expect(jp2.height).to eq 100
+      expect(jp2.width).to eq 100
+    end
+  end
+
+  context 'when preserve_tmp_source is provided' do
+    before do
+      generate_test_image(TEST_JPEG_INPUT_FILE)
+    end
+
+    let(:input_path) { TEST_JPEG_INPUT_FILE }
+    let(:creator) { described_class.new(ai, output: TEST_JP2_OUTPUT_FILE, preserve_tmp_source: true) }
+
+    it 'creates a jp2 and preserves the temporary file' do
+      expect(File).to exist TEST_JPEG_INPUT_FILE
+      expect(result).to be_a_kind_of Assembly::Image
+      expect(result.path).to eq TEST_JP2_OUTPUT_FILE
+      expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
+
+      # Indicates a temp tiff was created.
+      expect(creator.tmp_path).not_to be_nil
+      expect(File).to exist creator.tmp_path
+    end
+  end
+
+  context 'when the input file is a JPEG' do
+    before do
+      generate_test_image(TEST_JPEG_INPUT_FILE)
+    end
+
+    let(:input_path) { TEST_JPEG_INPUT_FILE }
+
+    it 'creates jp2 when given a JPEG' do
+      expect(File).to exist TEST_JPEG_INPUT_FILE
+      expect(File).not_to exist TEST_JP2_OUTPUT_FILE
+      expect(result).to be_a_kind_of Assembly::Image
+      expect(result.path).to eq TEST_JP2_OUTPUT_FILE
+      expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
+
+      # Indicates a temp tiff was created.
+      expect(creator.tmp_path).not_to be_nil
+      expect(File).not_to exist creator.tmp_path
+    end
+  end
+end

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -53,27 +53,6 @@ RSpec.describe Assembly::Image do
       end
     end
 
-    context 'when given an LZW compressed RGB tif' do
-      before do
-        generate_test_image(TEST_TIF_INPUT_FILE, compress: 'lzw')
-      end
-
-      it 'creates the jp2 with a temp file' do
-        expect(File).to exist TEST_TIF_INPUT_FILE
-        expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
-        # Indicates a temp tiff was not created.
-        expect(ai.tmp_path).not_to be_nil
-        expect(result).to be_a_kind_of described_class
-        expect(result.path).to eq TEST_JP2_OUTPUT_FILE
-        expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
-        expect(result.exif.colorspace).to eq 'sRGB'
-        jp2 = described_class.new(TEST_JP2_OUTPUT_FILE)
-        expect(jp2.height).to eq 100
-        expect(jp2.width).to eq 100
-      end
-    end
-
     context 'when given an uncompressed compressed RGB tif with more than 4GB of image data', skip: 'This test will create a 4GB test image and a 4GB temporary image, so skipping by default.' do
       before do
         generate_test_image(TEST_TIF_INPUT_FILE, compress: 'none', width: '37838', height: '37838')
@@ -249,26 +228,6 @@ RSpec.describe Assembly::Image do
       end
     end
 
-    context 'when the input file is a JPEG' do
-      before do
-        generate_test_image(TEST_JPEG_INPUT_FILE)
-      end
-
-      let(:input_path) { TEST_JPEG_INPUT_FILE }
-
-      it 'creates jp2 when given a JPEG' do
-        expect(File).to exist TEST_JPEG_INPUT_FILE
-        expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
-        # Indicates a temp tiff was created.
-        expect(ai.tmp_path).not_to be_nil
-        expect(File).not_to exist ai.tmp_path
-        expect(result).to be_a_kind_of described_class
-        expect(result.path).to eq TEST_JP2_OUTPUT_FILE
-        expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
-      end
-    end
-
     context 'when an invalid tmp folder' do
       before do
         generate_test_image(TEST_JPEG_INPUT_FILE)
@@ -281,26 +240,6 @@ RSpec.describe Assembly::Image do
         expect(File).to exist TEST_JPEG_INPUT_FILE
         expect(File).not_to exist bogus_folder
         expect { ai.create_jp2(tmp_folder: bogus_folder) }.to raise_error
-      end
-    end
-
-    context 'when preserve_tmp_source is provided' do
-      before do
-        generate_test_image(TEST_JPEG_INPUT_FILE)
-      end
-
-      let(:input_path) { TEST_JPEG_INPUT_FILE }
-
-      it 'creates a jp2 and preserves the temporary file' do
-        expect(File).to exist TEST_JPEG_INPUT_FILE
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE, preserve_tmp_source: true)
-        # Indicates a temp tiff was created.
-        expect(ai.tmp_path).not_to be_nil
-        expect(File).to exist ai.tmp_path
-        expect(result).to be_a_kind_of described_class
-        expect(result.path).to eq TEST_JP2_OUTPUT_FILE
-        expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
-        expect(File.exist?(ai.tmp_path)).to be true
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

So that we separate the concerns about an image from the concern of making a JP2 derivative.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



