### PR TITLE
Remove unused option: preserve_tmp_source

### DIFF
--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -116,7 +116,6 @@ module Assembly
     #   * :output => path to the output JP2 file (default: mirrors the source file name and path, but with a .jp2 extension)
     #   * :overwrite => if set to false, an existing JP2 file with the same name won't be overwritten (default: false)
     #   * :tmp_folder =>  the temporary folder to use when creating the jp2 (default: '/tmp'); also used by imagemagick
-    #   * :preserve_tmp_source => if set to true, preserve the temporary file generated during the creation process and store path in 'tmp_path' attribute (default: false)
     #
     # Example:
     #   source_img=Assembly::Image.new('/input/path_to_file.tif')

--- a/spec/assembly/image/jp2_creator_spec.rb
+++ b/spec/assembly/image/jp2_creator_spec.rb
@@ -36,26 +36,6 @@ RSpec.describe Assembly::Image::Jp2Creator do
     end
   end
 
-  context 'when preserve_tmp_source is provided' do
-    before do
-      generate_test_image(TEST_JPEG_INPUT_FILE)
-    end
-
-    let(:input_path) { TEST_JPEG_INPUT_FILE }
-    let(:creator) { described_class.new(ai, output: TEST_JP2_OUTPUT_FILE, preserve_tmp_source: true) }
-
-    it 'creates a jp2 and preserves the temporary file' do
-      expect(File).to exist TEST_JPEG_INPUT_FILE
-      expect(result).to be_a_kind_of Assembly::Image
-      expect(result.path).to eq TEST_JP2_OUTPUT_FILE
-      expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
-
-      # Indicates a temp tiff was created.
-      expect(creator.tmp_path).not_to be_nil
-      expect(File).to exist creator.tmp_path
-    end
-  end
-
   context 'when the input file is a JPEG' do
     before do
       generate_test_image(TEST_JPEG_INPUT_FILE)


### PR DESCRIPTION

## Why was this change made? 🤔

This is never used in dlss code:
https://github.com/search?q=org%3Asul-dlss+preserve_tmp_source&type=code

So, not having it makes the code simpler and still meets our needs.

## How was this change tested? 🤨

CI


