### PR TITLE
refactor: spec var name and remove releases section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,53 +9,6 @@
 This gem contains classes used by the Stanford University Digital Library to
 perform image operations necessary for accessioning of content.
 
-## Releases
-
-* 0.0.1 initial release
-* 0.0.2 small bug fixes
-* 0.0.3 more bug fixes
-* 0.0.4 update jp2 creation method to restrict allowed input types and improve color profile handling
-* 0.0.5 updated documentation to yard format
-* 0.0.6 updated dependency declarations
-* 0.1.0 move color profile extraction to tmp folder instead of gem profiles folder
-* 0.1.1 fix problem with digest require statement
-* 0.1.2 move check for file existence to when an action occurs instead of object initialization; more error checking and messages on command execution
-* 0.1.3 added a filesize attribute to the file object to allow easy access to filesize in bytes
-* 0.1.4 added a new images class that allows you batch create jp2s from an input TIFF directory
-* 0.2.0 added a new method to the image class to handle TIFF "sanity-check" -- can be used to ensure TIFFs are valid before JP2 generation
-* 1.0.0 bump the version number up to an official production level release
-* 1.1.0 remove common object file behaviors to a separate gem and use that gem as a dependency
-* 1.1.1 minor changes to spec tests
-* 1.1.2 remove the addition of 'format' node to file types in content metadata generation
-* 1.1.3 changes to content metadata generation method: change md5 and sha1 computations so that they come from the assembly-objectfile gem,
-    and set preserve/publish/shelve attributes using mimetype defaults
-* 1.2.0 support tiffs that have embedded thumbnails when creating jp2
-* 1.2.1 raise a SecurityError if the user attempts to overwrite an existing jp2 when creating it, to make it easier to catch in assembly
-* 1.2.2 add height and width methods for an image that gets it from exif
-* 1.2.4 prepare for release listing on DLSS release board
-* 1.2.5 small change to use the jp2able method instead of the valid? method when creating jp2s
-* 1.2.6 update how version number is set to make it easier to show
-* 1.3.0 added a new method to the Assembly::Images class to allow for batch adding of color profiles to all tiffs in a directory; allow batch methods to run recursively
-* 1.3.1 remove content metadata generation method and add to assembly-objectfile gem instead
-* 1.3.3 update gemspec to force use of latest assembly-objectfile gem to allow gem to work in Ruby 1.9 projects
-* 1.3.4 update to latest version of lyberteam gems
-* 1.3.5 fix a problem that could occur if there were spaces in input filenames
-* 1.3.6 add new attribute to give you default jp2 filename that will be used
-* 1.3.7 add new attribute to give you default dpg jp2 filename
-* 1.3.8 allow for batch processing of image extensions other than tif
-* 1.3.9 create new methods for getting a color profile from exif and for force adding color profile to a single image
-* 1.4.0 and 1.4.1 set the imagemagick tmp folder location environment variable when creating jp2
-* 1.5.0 allow images with a color profile to have jp2 derivatives generated
-* 1.5.1 relax nokogiri version requirement
-* 1.6.1 bump version number of assembly-objectfile required to fix UTF-8 errors during JP2-create
-* 1.6.2-1.6.3 small change to jp2 generation to try and fix bug with tiffs that have multiple input profile layers
-* 1.6.4 added in some additional checks to try and create jp2s with mismatching exif data
-* 1.6.5 fix problem with lack of extension in incoming tif causing a problem when creating jp2
-* 1.6.7 release to github/rubygems
-* 1.6.9 update mini_exiftool
-* 1.7.1 for jp2, only transcode to tiff if not a tiff
-* 1.7.3 for jp2, only transcode to tiff if not an uncompressed tiff
-
 ## Notes
 
 1. The gem assumes that the user context in which it is executed has write access to the 'tmp' folder.

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Assembly::Image do
-  let(:ai) { described_class.new(input_path) }
+  let(:assembly_image) { described_class.new(input_path) }
   let(:input_path) { TEST_TIF_INPUT_FILE }
 
   after do
@@ -14,14 +14,14 @@ RSpec.describe Assembly::Image do
 
   describe '#jp2_filename' do
     it 'indicates the default jp2 filename' do
-      expect(ai.jp2_filename).to eq TEST_TIF_INPUT_FILE.gsub('.tif', '.jp2')
+      expect(assembly_image.jp2_filename).to eq TEST_TIF_INPUT_FILE.gsub('.tif', '.jp2')
     end
 
     context 'with a file with no extension' do
       let(:input_path) { '/path/to/a/file_with_no_extension' }
 
       it 'indicates the default jp2 filename' do
-        expect(ai.jp2_filename).to eq '/path/to/a/file_with_no_extension.jp2'
+        expect(assembly_image.jp2_filename).to eq '/path/to/a/file_with_no_extension.jp2'
       end
     end
   end
@@ -31,7 +31,7 @@ RSpec.describe Assembly::Image do
       let(:input_path) { TEST_DPG_TIF_INPUT_FILE }
 
       it 'indicates the default DPG jp2 filename' do
-        expect(ai.dpg_jp2_filename).to eq TEST_DPG_TIF_INPUT_FILE.gsub('.tif', '.jp2').gsub('_00_', '_05_')
+        expect(assembly_image.dpg_jp2_filename).to eq TEST_DPG_TIF_INPUT_FILE.gsub('.tif', '.jp2').gsub('_00_', '_05_')
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Assembly::Image do
       let(:input_path) { '/path/to/a/file_with_no_00_extension' }
 
       it 'indicates the default jp2 filename' do
-        expect(ai.dpg_jp2_filename).to eq '/path/to/a/file_with_no_05_extension.jp2'
+        expect(assembly_image.dpg_jp2_filename).to eq '/path/to/a/file_with_no_05_extension.jp2'
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe Assembly::Image do
       let(:input_path) { '' }
 
       it 'does not run if no input file is passed in' do
-        expect { ai.create_jp2 }.to raise_error
+        expect { assembly_image.create_jp2 }.to raise_error
       end
     end
 
@@ -61,8 +61,8 @@ RSpec.describe Assembly::Image do
       it 'creates the jp2 with a temp file' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
-        expect(ai.tmp_path).not_to be_nil
+        result = assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+        expect(assembly_image.tmp_path).not_to be_nil
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq TEST_JP2_OUTPUT_FILE
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
@@ -81,8 +81,8 @@ RSpec.describe Assembly::Image do
       it 'creates the jp2 with a temp file' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
-        expect(ai.tmp_path).not_to be_nil
+        result = assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+        expect(assembly_image.tmp_path).not_to be_nil
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq TEST_JP2_OUTPUT_FILE
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
@@ -102,7 +102,7 @@ RSpec.describe Assembly::Image do
       it 'creates grayscale jp2' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+        result = assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE)
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
         expect(result.exif.colorspace).to eq 'Grayscale'
       end
@@ -116,8 +116,8 @@ RSpec.describe Assembly::Image do
       it 'creates color jp2' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        expect(ai).not_to have_color_profile
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+        expect(assembly_image).not_to have_color_profile
+        result = assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE)
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
         expect(result.exif.colorspace).to eq 'sRGB'
       end
@@ -131,8 +131,8 @@ RSpec.describe Assembly::Image do
       it 'creates grayscale jp2' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        expect(ai).not_to have_color_profile
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+        expect(assembly_image).not_to have_color_profile
+        result = assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE)
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
         expect(result.exif.colorspace).to eq 'Grayscale'
       end
@@ -146,8 +146,8 @@ RSpec.describe Assembly::Image do
       it 'creates color jp2' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        expect(ai).not_to have_color_profile
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+        expect(assembly_image).not_to have_color_profile
+        result = assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE)
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
         expect(result.exif.colorspace).to eq 'sRGB'
       end
@@ -161,10 +161,10 @@ RSpec.describe Assembly::Image do
       it 'creates a jp2' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        expect(ai).not_to have_color_profile
-        expect(ai).to be_a_valid_image
-        expect(ai).to be_jp2able
-        ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+        expect(assembly_image).not_to have_color_profile
+        expect(assembly_image).to be_a_valid_image
+        expect(assembly_image).to be_jp2able
+        assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE)
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
       end
     end
@@ -178,7 +178,7 @@ RSpec.describe Assembly::Image do
       it 'does not run' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).to exist TEST_JP2_OUTPUT_FILE
-        expect { ai.create_jp2(output: TEST_JP2_OUTPUT_FILE) }.to raise_error(SecurityError)
+        expect { assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE) }.to raise_error(SecurityError)
       end
     end
 
@@ -188,8 +188,8 @@ RSpec.describe Assembly::Image do
       end
 
       it 'gets the correct image height and width' do
-        expect(ai.height).to eq 100
-        expect(ai.width).to eq 100
+        expect(assembly_image.height).to eq 100
+        expect(assembly_image.width).to eq 100
       end
     end
 
@@ -201,10 +201,10 @@ RSpec.describe Assembly::Image do
       it 'does not run' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).not_to exist TEST_JP2_OUTPUT_FILE
-        expect(ai).not_to have_color_profile
-        expect(ai).to be_a_valid_image
-        expect(ai).to be_jp2able
-        ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+        expect(assembly_image).not_to have_color_profile
+        expect(assembly_image).to be_a_valid_image
+        expect(assembly_image).to be_jp2able
+        assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE)
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
         jp2_file = described_class.new(TEST_JP2_OUTPUT_FILE)
         expect(jp2_file).to be_valid_image
@@ -220,7 +220,7 @@ RSpec.describe Assembly::Image do
 
       it 'runs, because this is not currently an option' do
         expect(File).to exist TEST_TIF_INPUT_FILE
-        result = ai.create_jp2(output_profile: 'bogusness')
+        result = assembly_image.create_jp2(output_profile: 'bogusness')
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq TEST_JP2_INPUT_FILE
         expect(TEST_JP2_INPUT_FILE).to be_a_jp2
@@ -239,7 +239,7 @@ RSpec.describe Assembly::Image do
         bogus_folder = '/crapsticks'
         expect(File).to exist TEST_JPEG_INPUT_FILE
         expect(File).not_to exist bogus_folder
-        expect { ai.create_jp2(tmp_folder: bogus_folder) }.to raise_error
+        expect { assembly_image.create_jp2(tmp_folder: bogus_folder) }.to raise_error
       end
     end
 
@@ -251,7 +251,7 @@ RSpec.describe Assembly::Image do
       it 'creates a jp2 of the same filename and in the same location as the input and cleans up the tmp file' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File.exist?(TEST_JP2_INPUT_FILE)).to be false
-        result = ai.create_jp2
+        result = assembly_image.create_jp2
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq TEST_JP2_INPUT_FILE
         expect(TEST_JP2_INPUT_FILE).to be_a_jp2
@@ -268,7 +268,7 @@ RSpec.describe Assembly::Image do
       it 'recreates jp2' do
         expect(File).to exist TEST_TIF_INPUT_FILE
         expect(File).to exist TEST_JP2_OUTPUT_FILE
-        result = ai.create_jp2(output: TEST_JP2_OUTPUT_FILE, overwrite: true)
+        result = assembly_image.create_jp2(output: TEST_JP2_OUTPUT_FILE, overwrite: true)
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq TEST_JP2_OUTPUT_FILE
         expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2


### PR DESCRIPTION
## Why was this change made? 🤔

for world peace.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



