### PR TITLE
Add support for 4-channel CMYK encoded images

### DIFF
--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -279,7 +279,7 @@ module Assembly
       options << '-limit memory 1GiB -limit map 1GiB'
 
       case samples_per_pixel
-      when 3
+      when 3..4
         options << '-type TrueColor'
       when 1
         options << '-depth 8' # force the production of a grayscale access derivative

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -46,6 +46,42 @@ describe Assembly::Image do
   #   expect(@jp2.width).to eq 100
   # end
 
+  it 'creates the jp2 with a temp file when given an CMYK jpeg' do
+    generate_test_image(TEST_JPEG_INPUT_FILE, colorspace: 'CMYK', profile: '', color: 'optimize')
+    expect(File).to exist TEST_JPEG_INPUT_FILE
+    expect(File).to_not exist TEST_JP2_OUTPUT_FILE
+    @ai = Assembly::Image.new(TEST_JPEG_INPUT_FILE)
+    expect(@ai.exif['ColorComponents']).to eql 4
+    result = @ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+    # Indicates a temp tiff was not created.
+    expect(@ai.tmp_path).to_not be_nil
+    expect(result).to be_a_kind_of Assembly::Image
+    expect(result.path).to eq TEST_JP2_OUTPUT_FILE
+    expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
+    expect(result.exif.colorspace).to eq 'sRGB'
+    @jp2 = Assembly::Image.new(TEST_JP2_OUTPUT_FILE)
+    expect(@jp2.height).to eq 100
+    expect(@jp2.width).to eq 100
+  end
+
+  it 'creates the jp2 with a temp file when given an CMYK tif' do
+    generate_test_image(TEST_TIF_INPUT_FILE, colorspace: 'CMYK', profile: '', color: 'optimize')
+    expect(File).to exist TEST_TIF_INPUT_FILE
+    expect(File).to_not exist TEST_JP2_OUTPUT_FILE
+    @ai = Assembly::Image.new(TEST_TIF_INPUT_FILE)
+    expect(@ai.exif['SamplesPerPixel']).to eql 4
+    result = @ai.create_jp2(output: TEST_JP2_OUTPUT_FILE)
+    # Indicates a temp tiff was not created.
+    expect(@ai.tmp_path).to_not be_nil
+    expect(result).to be_a_kind_of Assembly::Image
+    expect(result.path).to eq TEST_JP2_OUTPUT_FILE
+    expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
+    expect(result.exif.colorspace).to eq 'sRGB'
+    @jp2 = Assembly::Image.new(TEST_JP2_OUTPUT_FILE)
+    expect(@jp2.height).to eq 100
+    expect(@jp2.width).to eq 100
+  end
+
   it 'creates the jp2 with a temp file when given an LZW compressed RGB tif' do
     generate_test_image(TEST_TIF_INPUT_FILE, compress: 'lzw')
     expect(File).to exist TEST_TIF_INPUT_FILE

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,9 @@ def generate_test_image(file, params = {})
   color = params[:color] || 'TrueColor'
   profile = params[:profile] || 'sRGBIEC6196621'
   image_type = params[:image_type]
+  colorspace = params[:colorspace]
   create_command = "convert rose: -scale #{width}x#{height}\! -type #{color} "
+  create_command += " -colorspace #{colorspace} " if params[:colorspace]
   create_command += ' -profile ' + File.join(Assembly::PATH_TO_IMAGE_GEM, 'profiles', profile + '.icc') + ' ' unless profile == ''
   create_command += " -type #{image_type} " if image_type
   create_command += ' -compress lzw ' if params[:compress]


### PR DESCRIPTION
## Why was this change made? 🤔

@calavano is this ready to be a PR?  

- would we want to add a CMYK image in the test data and create a spec to test this?
- would we want to perform some other kind of automated test?  (e.g. add data and a test in common-accessioning code?)
- or has this gotta be tested with a person/

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



