### PR TITLE
rubocop: remove cop due to rubocop backwards incompatibility semver fooch

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,8 +25,6 @@ Naming/FileName:
 Style/WordArray:
   Enabled: false
 
-Gemspec/DateAssignment: # new in 1.10
-  Enabled: true
 Gemspec/RequireMFA: # new in 1.23
   Enabled: true
 Layout/LineEndStringConcatenationIndentation: # new in 1.18


### PR DESCRIPTION
## Why was this change made? 🤔

So rubocop passes in CI

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



