### PR TITLE
Always use bigtiff for temporary images

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
     mime-types-data (3.2022.0105)
     mini_exiftool (2.10.2)
     minitest (5.16.2)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -98,6 +100,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -98,7 +98,6 @@ module Assembly
     #   derivative_img=source_img.create_jp2(:overwrite=>true)
     #   puts derivative_img.mimetype # 'image/jp2'
     #   puts derivative_image.path # '/input/path_to_file.jp2'
-    # rubocop:disable Metrics/CyclomaticComplexity:
     def create_jp2(params = {})
       Jp2Creator.create(self, params)
     end
@@ -112,25 +111,6 @@ module Assembly
           1
         when 'image/jpeg'
           3
-        end
-      end
-    end
-
-    # Get size of image data in bytes
-    def image_data_size
-      (samples_per_pixel * height * width * bits_per_sample) / 8
-    end
-
-    private
-
-    # rubocop:enable Metrics/CyclomaticComplexity
-    def bits_per_sample
-      if exif['bitspersample']
-        exif['bitspersample'].to_i
-      else
-        case mimetype
-        when 'image/tiff'
-          1
         end
       end
     end

--- a/lib/assembly-image/jp2_creator.rb
+++ b/lib/assembly-image/jp2_creator.rb
@@ -100,11 +100,6 @@ module Assembly
         raise SecurityError, 'cannot recreate jp2 over itself' if overwrite? && image.mimetype == 'image/jp2' && output_path == image.path
       end
 
-      # Bigtiff needs to be used if size of image exceeds 2^32 bytes.
-      def need_bigtiff?
-        image.image_data_size >= 2**32
-      end
-
       # We do this because we need to reliably compress the tiff and KDUcompress doesn’t support arbitrary image types
       # rubocop:disable Metrics/MethodLength
       def make_tmp_tiff(tmp_folder: nil)
@@ -124,7 +119,7 @@ module Assembly
                        vips_image
                      end
 
-        vips_image.tiffsave(tmp_path, bigtiff: need_bigtiff?)
+        vips_image.tiffsave(tmp_path, bigtiff: true) # Use bigtiff so we can support images > 4GB
         tmp_path
       end
       # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
## Why was this change made? 🤔
This cuts down on the complexity of the code.
Fixes #84

@calavano said:
> Since we’re only using it for the temporary tiff, and if we’re confident in kakadu handling the files, then it should be fine. If we use something else in the future, then it could become a problem.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



