### PR TITLE
Use libvips to see if this is an sRGB

### DIFF
--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -65,9 +65,9 @@ module Assembly
       Jp2Creator.create(self, params)
     end
 
-    def samples_per_pixel
+    def srgb?
       vips_image = Vips::Image.new_from_file path
-      vips_image.bands
+      vips_image.interpretation == :srgb
     end
   end
 end

--- a/lib/assembly-image/jp2_creator.rb
+++ b/lib/assembly-image/jp2_creator.rb
@@ -69,7 +69,7 @@ module Assembly
       def jp2_create_command(source_path:, output:)
         options = []
         # TODO: Consider using ruby-vips to determine the colorspace instead of relying on exif (which is done below)
-        options << '-jp2_space sRGB' if image.samples_per_pixel == 3
+        options << '-jp2_space sRGB' if image.srgb?
         options += KDU_COMPRESS_DEFAULT_OPTIONS
         options << "Clayers=#{layers}"
         "kdu_compress #{options.join(' ')} -i '#{source_path}' -o '#{output}' 2>&1"


### PR DESCRIPTION


## Why was this change made? 🤔

Ref #54

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



