### PR TITLE
Bump sul-dlss circleci orb to 3.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby-rails: sul-dlss/ruby-rails@3.0.1
+  ruby-rails: sul-dlss/ruby-rails@3.1.2
 workflows:
   build:
     jobs:


### PR DESCRIPTION
## Why was this change made? 🤔

Let's ensure we run ALL the specs.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



