### PR TITLE
Use libvips to see if it has an ICC profile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,10 @@ Naming/FileName:
 Style/WordArray:
   Enabled: false
 
+Naming/PredicateName:
+  ForbiddenPrefixes:
+    - is_
+    
 Gemspec/RequireMFA: # new in 1.23
   Enabled: true
 Layout/LineEndStringConcatenationIndentation: # new in 1.18

--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -7,16 +7,6 @@ require_relative 'jp2_creator'
 module Assembly
   # The Image class contains methods to operate on an image.
   class Image < Assembly::ObjectFile
-    # Get the image color profile
-    #
-    # @return [string] image color profile
-    # Example:
-    #   source_img=Assembly::Image.new('/input/path_to_file.tif')
-    #   puts source_img.profile # gives 'Adobe RGB 1998'
-    def profile
-      exif.nil? ? nil : exif['profiledescription']
-    end
-
     # Get the image height from exif data
     #
     # @return [integer] image height in pixels
@@ -71,6 +61,11 @@ module Assembly
 
     def srgb?
       vips_image.interpretation == :srgb
+    end
+
+    # Does the image include an ICC profile?
+    def has_profile?
+      vips_image.get_fields.include?('icc-profile-data')
     end
   end
 end

--- a/lib/assembly-image/jp2_creator.rb
+++ b/lib/assembly-image/jp2_creator.rb
@@ -114,7 +114,7 @@ module Assembly
         tmp_path = tmp_tiff_file.path
         tiff_image = if vips_image.interpretation.eql?(:cmyk)
                        vips_image.icc_transform(SRGB_ICC, input_profile: CMYK_ICC)
-                     elsif !image.profile.nil?
+                     elsif image.has_profile?
                        vips_image.icc_transform(SRGB_ICC, embedded: true)
                      else
                        vips_image


### PR DESCRIPTION
## Why was this change made? 🤔
We don't want to use exif if we don't need to.

Ref #54 

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



