### PR TITLE
[refactor] Expose the vips_image

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     assembly-image (2.0.0)
+      activesupport (> 6.1)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
       ruby-vips (>= 2.0)

--- a/assembly-image.gemspec
+++ b/assembly-image.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
+  s.add_dependency 'activesupport', '> 6.1'
   s.add_dependency 'assembly-objectfile', '>= 1.6.4'
   s.add_dependency 'mini_exiftool', '>= 1.6', '< 3'
   s.add_dependency 'ruby-vips', '>= 2.0'

--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -65,8 +65,11 @@ module Assembly
       Jp2Creator.create(self, params)
     end
 
+    def vips_image
+      @vips_image ||= Vips::Image.new_from_file path
+    end
+
     def srgb?
-      vips_image = Vips::Image.new_from_file path
       vips_image.interpretation == :srgb
     end
   end


### PR DESCRIPTION


## Why was this change made? 🤔

So we don't do this 3 times

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



