### PR TITLE
Autorotate temporary tiff file

### DIFF
--- a/lib/assembly-image/jp2_creator.rb
+++ b/lib/assembly-image/jp2_creator.rb
@@ -105,6 +105,7 @@ module Assembly
 
       # We do this because we need to reliably compress the tiff and KDUcompress doesn’t support arbitrary image types
       # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def make_tmp_tiff(tmp_folder: nil)
         tmp_folder ||= Dir.tmpdir
         raise "tmp_folder #{tmp_folder} does not exists" unless File.exist?(tmp_folder)
@@ -120,9 +121,10 @@ module Assembly
                        vips_image
                      end
 
-        tiff_image.tiffsave(tmp_path, bigtiff: true) # Use bigtiff so we can support images > 4GB
+        tiff_image.autorot.tiffsave(tmp_path, bigtiff: true) # Use bigtiff so we can support images > 4GB
         tmp_path
       end
+      # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
     end
   end

--- a/spec/assembly/image/jp2_creator_spec.rb
+++ b/spec/assembly/image/jp2_creator_spec.rb
@@ -11,6 +11,20 @@ RSpec.describe Assembly::Image::Jp2Creator do
 
   before { cleanup }
 
+  describe '#make_tmp_tiff' do
+    subject(:tiff_file) { creator.send(:make_tmp_tiff) }
+
+    let(:input_path) { 'spec/test_data/color_rgb_srgb_rot90cw.tif' }
+    let(:vips_output) { Vips::Image.new_from_file tiff_file }
+    let(:plum) { [94.0, 58.0, 101.0] }
+
+    context 'when given a tiff with a rotation hint' do
+      it 'rotates it' do
+        expect(vips_output.getpoint(3, 3)).to eq plum
+      end
+    end
+  end
+
   context 'when given an LZW compressed RGB tif' do
     before do
       generate_test_image(TEST_TIF_INPUT_FILE, compress: 'lzw')


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #37

## How was this change tested? 🤨

Tested on the console via:

```ruby
image = Assembly::Image.new('spec/test_data/color_rgb_srgb_rot90cw.tif')
creator = Assembly::Image::Jp2Creator.new(image, {})
creator.send(:make_tmp_tiff)
```

