### PR TITLE
[refactor] Prefer kwargs to a hash argument

### DIFF
--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -27,19 +27,18 @@ module Assembly
     # Create a JP2 file for the current image.
     # Important note: this will not work for multipage TIFFs.
     #
-    # @param [Hash] params Optional parameters
-    #   * :output => path to the output JP2 file (default: mirrors the source file name and path, but with a .jp2 extension)
-    #   * :overwrite => if set to false, an existing JP2 file with the same name won't be overwritten (default: false)
-    #   * :tmp_folder =>  the temporary folder to use when creating the jp2 (default: '/tmp'); also used by imagemagick
+    # @param [String] output path to the output JP2 file (default: mirrors the source file name and path, but with a .jp2 extension)
+    # @param [Boolean] overwrite if set to false, an existing JP2 file with the same name won't be overwritten (default: false)
+    # @param [Dir] tmp_folder the temporary folder to use when creating the jp2 (default: '/tmp'); also used by imagemagick
     # @return [Assembly::Image] object containing the generated JP2 file
     #
     # Example:
     #   source_img = Assembly::Image.new('/dir/path_to_file.tif')
-    #   jp2_img = source_img.create_jp2(:overwrite=>true)
+    #   jp2_img = source_img.create_jp2(overwrite: true)
     #   jp2_img.mimetype # 'image/jp2'
     #   jp2_img.path # '/dir/path_to_file.jp2'
-    def create_jp2(params = {})
-      Jp2Creator.create(self, params)
+    def create_jp2(**params)
+      Jp2Creator.create(self, **params)
     end
 
     def vips_image

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -258,21 +258,6 @@ RSpec.describe Assembly::Image do
       end
     end
 
-    context 'when you specify a bogus output profile' do
-      before do
-        generate_test_image(input_path)
-      end
-
-      it 'runs, because this is not currently an option' do
-        expect(File).to exist input_path
-        result = assembly_image.create_jp2(output_profile: 'bogusness')
-        expect(result).to be_a_kind_of described_class
-        expect(result.path).to eq TEST_JP2_INPUT_FILE
-        expect(TEST_JP2_INPUT_FILE).to be_a_jp2
-        expect(result.exif.colorspace).to eq 'sRGB'
-      end
-    end
-
     context 'when an invalid tmp folder' do
       before do
         generate_test_image(TEST_JPEG_INPUT_FILE)


### PR DESCRIPTION
Hold please:
- wait for functional changes to go out to prod first
- will need to coordinate this with consumer apps (common-accessioning, was_robot_suite)

## Why was this change made? 🤔
kwargs are better at verifying what you sent to the method was a valid option.


## How was this change tested? 🤨
CI

