### PR TITLE
[refactor] image.rb: comments tightened up

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-21
   x86_64-linux
 

--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -7,50 +7,37 @@ require_relative 'jp2_creator'
 module Assembly
   # The Image class contains methods to operate on an image.
   class Image < Assembly::ObjectFile
-    # Get the image height from exif data
-    #
     # @return [integer] image height in pixels
-    # Example:
-    #   source_img=Assembly::Image.new('/input/path_to_file.tif')
-    #   puts source_img.height # gives 100
     def height
       exif.imageheight
     end
 
-    # Get the image width from exif data
-    # @return [integer] image height in pixels
-    # Example:
-    #   source_img=Assembly::Image.new('/input/path_to_file.tif')
-    #   puts source_img.width # gives 100
+    # @return [integer] image width in pixels
     def width
       exif.imagewidth
     end
 
-    # Returns the full default jp2 path and filename that will be created from the given image
-    #
     # @return [string] full default jp2 path and filename that will be created from the given image
-    # Example:
-    #   source_img=Assembly::Image.new('/input/path_to_file.tif')
-    #   puts source_img.jp2_filename # gives /input/path_to_file.jp2
+    # Example:  given original file of '/dir/path_to_file.tif', gives '/dir/path_to_file.jp2'
     def jp2_filename
+      # path is a property on Assembly::ObjectFile
       File.extname(path).empty? ? "#{path}.jp2" : path.gsub(File.extname(path), '.jp2')
     end
 
     # Create a JP2 file for the current image.
     # Important note: this will not work for multipage TIFFs.
     #
-    # @return [Assembly::Image] object containing the generated JP2 file
-    #
-    # @param [Hash] params Optional parameters specified as a hash, using symbols for options:
+    # @param [Hash] params Optional parameters
     #   * :output => path to the output JP2 file (default: mirrors the source file name and path, but with a .jp2 extension)
     #   * :overwrite => if set to false, an existing JP2 file with the same name won't be overwritten (default: false)
     #   * :tmp_folder =>  the temporary folder to use when creating the jp2 (default: '/tmp'); also used by imagemagick
+    # @return [Assembly::Image] object containing the generated JP2 file
     #
     # Example:
-    #   source_img=Assembly::Image.new('/input/path_to_file.tif')
-    #   derivative_img=source_img.create_jp2(:overwrite=>true)
-    #   puts derivative_img.mimetype # 'image/jp2'
-    #   puts derivative_image.path # '/input/path_to_file.jp2'
+    #   source_img = Assembly::Image.new('/dir/path_to_file.tif')
+    #   jp2_img = source_img.create_jp2(:overwrite=>true)
+    #   jp2_img.mimetype # 'image/jp2'
+    #   jp2_img.path # '/dir/path_to_file.jp2'
     def create_jp2(params = {})
       Jp2Creator.create(self, params)
     end


### PR DESCRIPTION
## Why was this change made? 🤔

there was a lot of noise in the comments.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



