### PR TITLE
preserve rotation in vips_image and jp2

### DIFF
--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -43,7 +43,8 @@ module Assembly
     end
 
     def vips_image
-      @vips_image ||= Vips::Image.new_from_file path
+      # autorot will only affect images that need rotation: https://www.libvips.org/API/current/libvips-conversion.html#vips-autorot
+      @vips_image ||= Vips::Image.new_from_file(path).autorot
     end
 
     def srgb?

--- a/spec/assembly/image/jp2_creator_spec.rb
+++ b/spec/assembly/image/jp2_creator_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 RSpec.describe Assembly::Image::Jp2Creator do
   subject(:result) { creator.create }
 
-  let(:ai) { Assembly::Image.new(input_path) }
+  let(:assembly_image) { Assembly::Image.new(input_path) }
   let(:input_path) { TEST_TIF_INPUT_FILE }
-  let(:creator) { described_class.new(ai, output: TEST_JP2_OUTPUT_FILE) }
+  let(:creator) { described_class.new(assembly_image, output: TEST_JP2_OUTPUT_FILE) }
 
   before { cleanup }
 
@@ -49,6 +49,21 @@ RSpec.describe Assembly::Image::Jp2Creator do
       # Indicates a temp tiff was created.
       expect(creator.tmp_path).not_to be_nil
       expect(File).not_to exist creator.tmp_path
+    end
+  end
+
+  describe '#make_tmp_tiff' do
+    subject(:tiff_file) { creator.send(:make_tmp_tiff) }
+
+    let(:input_path) { 'spec/test_data/color_rgb_srgb_rot90cw.tif' }
+    let(:vips_output) { Vips::Image.new_from_file tiff_file }
+    let(:plum) { [94.0, 58.0, 101.0] }
+
+    context 'when given a tiff with a rotation hint' do
+      it 'rotates it' do
+        expect(Vips::Image.new_from_file(input_path).getpoint(3, 3)).not_to eq plum
+        expect(vips_output.getpoint(3, 3)).to eq plum
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #37

supersedes PR #91 as @calavano recommended preserving the rotation indicated in the source image in the original Vips image object, rather than the temporary tiff.  This means the image height and width, for example, will be correct to the rotation.

## How was this change tested? 🤨

I used the spec from PR #91 and @jcoyne verified that visually, too.

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



