### PR TITLE
get height and width from vips

### DIFF
--- a/lib/assembly-image/image.rb
+++ b/lib/assembly-image/image.rb
@@ -9,12 +9,12 @@ module Assembly
   class Image < Assembly::ObjectFile
     # @return [integer] image height in pixels
     def height
-      exif.imageheight
+      vips_image.height
     end
 
     # @return [integer] image width in pixels
     def width
-      exif.imagewidth
+      vips_image.width
     end
 
     # @return [string] full default jp2 path and filename that will be created from the given image

--- a/lib/assembly-image/jp2_creator.rb
+++ b/lib/assembly-image/jp2_creator.rb
@@ -71,7 +71,6 @@ module Assembly
 
       def jp2_create_command(source_path:, output:)
         options = []
-        # TODO: Consider using ruby-vips to determine the colorspace instead of relying on exif (which is done below)
         options << '-jp2_space sRGB' if image.srgb?
         options += KDU_COMPRESS_DEFAULT_OPTIONS
         options << "Clayers=#{layers}"


### PR DESCRIPTION
## Why was this change made? 🤔

Since we have a vips image object, let's use it.

Also got rid of no-longer relevant comment.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



