### PR TITLE
better attribute names

### DIFF
--- a/spec/assembly/image/jp2_creator_spec.rb
+++ b/spec/assembly/image/jp2_creator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Assembly::Image::Jp2Creator do
       expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
 
       # Indicates a temp tiff was not created.
-      expect(creator.tmp_path).not_to be_nil
+      expect(creator.tmp_tiff_path).not_to be_nil
       expect(result.exif.colorspace).to eq 'sRGB'
       jp2 = Assembly::Image.new(TEST_JP2_OUTPUT_FILE)
       expect(jp2.height).to eq 36
@@ -47,8 +47,8 @@ RSpec.describe Assembly::Image::Jp2Creator do
       expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
 
       # Indicates a temp tiff was created.
-      expect(creator.tmp_path).not_to be_nil
-      expect(File).not_to exist creator.tmp_path
+      expect(creator.tmp_tiff_path).not_to be_nil
+      expect(File).not_to exist creator.tmp_tiff_path
     end
   end
 end

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Assembly::Image do
         expect(File).to exist input_path
         expect(File).not_to exist jp2_output_file
         result = assembly_image.create_jp2(output: jp2_output_file)
-        expect(assembly_image.tmp_path).not_to be_nil
+        expect(assembly_image.tmp_tiff_path).not_to be_nil
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
         expect(jp2_output_file).to be_a_jp2
@@ -69,7 +69,7 @@ RSpec.describe Assembly::Image do
         expect(assembly_image).to be_a_valid_image
         expect(assembly_image).to be_jp2abl
         result = assembly_image.create_jp2(output: jp2_output_file)
-        expect(assembly_image.tmp_path).not_to be_nil
+        expect(assembly_image.tmp_tiff_path).not_to be_nil
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
         expect(jp2_output_file).to be_a_jp2


### PR DESCRIPTION
## Why was this change made? 🤔

Better names reduce cognitive load.  Or so goes the theory.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



