### PR TITLE
spec_helper: remove cruft

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,12 +22,15 @@ Naming/FileName:
   Exclude:
    - lib/assembly-image.rb
 
-Style/WordArray:
-  Enabled: false
-
 Naming/PredicateName:
   ForbiddenPrefixes:
     - is_
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
 
 Gemspec/RequireMFA: # new in 1.23
   Enabled: true

--- a/spec/assembly/image/jp2_creator_spec.rb
+++ b/spec/assembly/image/jp2_creator_spec.rb
@@ -5,9 +5,11 @@ require 'spec_helper'
 RSpec.describe Assembly::Image::Jp2Creator do
   subject(:result) { creator.create }
 
+  let(:jp2_output_file) { File.join(TEST_OUTPUT_DIR, 'test.jp2') }
+
   let(:assembly_image) { Assembly::Image.new(input_path) }
   let(:input_path) { TEST_TIF_INPUT_FILE }
-  let(:creator) { described_class.new(assembly_image, output: TEST_JP2_OUTPUT_FILE) }
+  let(:creator) { described_class.new(assembly_image, output: jp2_output_file) }
 
   before { cleanup }
 
@@ -18,15 +20,15 @@ RSpec.describe Assembly::Image::Jp2Creator do
 
     it 'creates the jp2 with a temp file' do
       expect(File).to exist TEST_TIF_INPUT_FILE
-      expect(File).not_to exist TEST_JP2_OUTPUT_FILE
+      expect(File).not_to exist jp2_output_file
       expect(result).to be_a_kind_of Assembly::Image
-      expect(result.path).to eq TEST_JP2_OUTPUT_FILE
-      expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
+      expect(result.path).to eq jp2_output_file
+      expect(jp2_output_file).to have_jp2_mimetype
 
       # Indicates a temp tiff was not created.
       expect(creator.tmp_tiff_path).not_to be_nil
       expect(result.exif.colorspace).to eq 'sRGB'
-      jp2 = Assembly::Image.new(TEST_JP2_OUTPUT_FILE)
+      jp2 = Assembly::Image.new(jp2_output_file)
       expect(jp2.height).to eq 36
       expect(jp2.width).to eq 43
     end
@@ -41,10 +43,10 @@ RSpec.describe Assembly::Image::Jp2Creator do
 
     it 'creates jp2 when given a JPEG' do
       expect(File).to exist TEST_JPEG_INPUT_FILE
-      expect(File).not_to exist TEST_JP2_OUTPUT_FILE
+      expect(File).not_to exist jp2_output_file
       expect(result).to be_a_kind_of Assembly::Image
-      expect(result.path).to eq TEST_JP2_OUTPUT_FILE
-      expect(TEST_JP2_OUTPUT_FILE).to be_a_jp2
+      expect(result.path).to eq jp2_output_file
+      expect(jp2_output_file).to have_jp2_mimetype
 
       # Indicates a temp tiff was created.
       expect(creator.tmp_tiff_path).not_to be_nil

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Assembly::Image do
         expect(assembly_image.tmp_tiff_path).not_to be_nil
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         expect(result.exif.colorspace).to eq 'sRGB'
         expect(result.height).to eq 37_838
         expect(result.width).to eq 37_838
@@ -72,7 +72,7 @@ RSpec.describe Assembly::Image do
         expect(assembly_image.tmp_tiff_path).not_to be_nil
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         expect(result.exif.colorspace).to eq 'sRGB'
         expect(result.height).to eq 37_838
         expect(result.width).to eq 37_838
@@ -95,7 +95,7 @@ RSpec.describe Assembly::Image do
         result = assembly_image.create_jp2(output: jp2_output_file)
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         expect(result.exif.colorspace).to eq 'Grayscale'
       end
     end
@@ -118,7 +118,7 @@ RSpec.describe Assembly::Image do
         result = assembly_image.create_jp2(output: jp2_output_file)
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         expect(result.exif.colorspace).to eq 'sRGB'
       end
     end
@@ -139,7 +139,7 @@ RSpec.describe Assembly::Image do
         expect(assembly_image).to be_a_valid_image
         expect(assembly_image).to be_jp2able
         result = assembly_image.create_jp2(output: jp2_output_file)
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
         expect(result.exif.colorspace).to eq 'Grayscale'
@@ -164,7 +164,7 @@ RSpec.describe Assembly::Image do
         result = assembly_image.create_jp2(output: jp2_output_file)
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         expect(result.exif.colorspace).to eq 'sRGB'
       end
     end
@@ -187,7 +187,7 @@ RSpec.describe Assembly::Image do
         result = assembly_image.create_jp2(output: jp2_output_file)
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         # note, we verify the CMYK has been converted to an SRGB JP2 correctly by using ruby-vips instead of exif, since exif does not correctly
         #  identify the color space...note: this line current does not work in circleci, potentially due to libvips version differences
         expect(Vips::Image.new_from_file(jp2_output_file).get_value('interpretation')).to eq :srgb
@@ -210,7 +210,7 @@ RSpec.describe Assembly::Image do
         expect(assembly_image).to be_a_valid_image
         expect(assembly_image).to be_jp2able
         assembly_image.create_jp2(output: jp2_output_file)
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
       end
     end
 
@@ -250,7 +250,7 @@ RSpec.describe Assembly::Image do
         expect(assembly_image).to be_a_valid_image
         expect(assembly_image).to be_jp2able
         assembly_image.create_jp2(output: jp2_output_file)
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         jp2_file = described_class.new(jp2_output_file)
         expect(jp2_file).to be_valid_image
         expect(jp2_file).not_to be_jp2able
@@ -274,17 +274,19 @@ RSpec.describe Assembly::Image do
     end
 
     context 'when no output file is specified' do
+      let(:jp2_input_file) { File.join(TEST_INPUT_DIR, 'test.jp2') }
+
       before do
         generate_test_image(input_path)
       end
 
       it 'creates a jp2 of the same filename and in the same location as the input and cleans up the tmp file' do
         expect(File).to exist input_path
-        expect(File.exist?(TEST_JP2_INPUT_FILE)).to be false
+        expect(File.exist?(jp2_input_file)).to be false
         result = assembly_image.create_jp2
         expect(result).to be_a_kind_of described_class
-        expect(result.path).to eq TEST_JP2_INPUT_FILE
-        expect(TEST_JP2_INPUT_FILE).to be_a_jp2
+        expect(result.path).to eq jp2_input_file
+        expect(jp2_input_file).to have_jp2_mimetype
         expect(result.exif.colorspace).to eq 'sRGB'
       end
     end
@@ -301,7 +303,7 @@ RSpec.describe Assembly::Image do
         result = assembly_image.create_jp2(output: jp2_output_file, overwrite: true)
         expect(result).to be_a_kind_of described_class
         expect(result.path).to eq jp2_output_file
-        expect(jp2_output_file).to be_a_jp2
+        expect(jp2_output_file).to have_jp2_mimetype
         expect(result.exif.colorspace).to eq 'sRGB'
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,18 +7,12 @@ end
 
 bootfile = File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 require bootfile
-require 'ruby-vips'
 require 'pry-byebug'
 
 TEST_INPUT_DIR       = File.join(Assembly::PATH_TO_IMAGE_GEM, 'spec', 'test_data', 'input')
 TEST_OUTPUT_DIR      = File.join(Assembly::PATH_TO_IMAGE_GEM, 'spec', 'test_data', 'output')
 TEST_TIF_INPUT_FILE  = File.join(TEST_INPUT_DIR, 'test.tif')
 TEST_JPEG_INPUT_FILE = File.join(TEST_INPUT_DIR, 'test.jpg')
-TEST_JP2_INPUT_FILE  = File.join(TEST_INPUT_DIR, 'test.jp2')
-TEST_JP2_OUTPUT_FILE = File.join(TEST_OUTPUT_DIR, 'test.jp2')
-TEST_PROFILE_DIR     = File.join(Assembly::PATH_TO_IMAGE_GEM, 'profiles')
-TEST_DATA_DIR        = File.join(Assembly::PATH_TO_IMAGE_GEM, 'spec', 'test_data')
-TEST_DRUID           = 'nx288wh8889'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -204,7 +198,7 @@ def generate_test_image(file, params = {})
 
   options = {}
   unless profile.nil?
-    profile_file = File.join(TEST_PROFILE_DIR, profile + '.icc')
+    profile_file = File.join(Assembly::PATH_TO_IMAGE_GEM, 'profiles', profile + '.icc')
     options.merge!(profile: profile_file)
   end
 
@@ -236,7 +230,7 @@ def remove_files(dir)
   end
 end
 
-RSpec::Matchers.define :be_a_jp2 do
+RSpec::Matchers.define :have_jp2_mimetype do
   match do |actual|
     if File.exist?(actual)
       exif = MiniExiftool.new actual


### PR DESCRIPTION
## Why was this change made? 🤔

- remove unused code
- It's annoying to have to look in spec_helper for definitions, especially if they are only used in one spec file.
- rename rspec matcher to be more accurate

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



