### PR TITLE
add working cmyk image spec

### DIFF
--- a/spec/assembly/image/jp2_creator_spec.rb
+++ b/spec/assembly/image/jp2_creator_spec.rb
@@ -3,30 +3,30 @@
 require 'spec_helper'
 
 RSpec.describe Assembly::Image::Jp2Creator do
-  subject(:result) { creator.create }
+  subject(:result) { jp2creator.create }
 
   let(:jp2_output_file) { File.join(TEST_OUTPUT_DIR, 'test.jp2') }
 
   let(:assembly_image) { Assembly::Image.new(input_path) }
   let(:input_path) { TEST_TIF_INPUT_FILE }
-  let(:creator) { described_class.new(assembly_image, output: jp2_output_file) }
+  let(:jp2creator) { described_class.new(assembly_image, output: jp2_output_file) }
 
   before { cleanup }
 
   context 'when given an LZW compressed RGB tif' do
     before do
-      generate_test_image(TEST_TIF_INPUT_FILE, compress: 'lzw')
+      generate_test_image(input_path, compress: 'lzw')
     end
 
     it 'creates the jp2 with a temp file' do
-      expect(File).to exist TEST_TIF_INPUT_FILE
+      expect(File).to exist input_path
       expect(File).not_to exist jp2_output_file
       expect(result).to be_a_kind_of Assembly::Image
       expect(result.path).to eq jp2_output_file
       expect(jp2_output_file).to have_jp2_mimetype
 
       # Indicates a temp tiff was not created.
-      expect(creator.tmp_tiff_path).not_to be_nil
+      expect(jp2creator.tmp_tiff_path).not_to be_nil
       expect(result.exif.colorspace).to eq 'sRGB'
       jp2 = Assembly::Image.new(jp2_output_file)
       expect(jp2.height).to eq 36
@@ -34,12 +34,38 @@ RSpec.describe Assembly::Image::Jp2Creator do
     end
   end
 
+  context 'when given a cmyk tif' do
+    let(:input_path) { File.join(TEST_INPUT_DIR, 'test-cmyk.tif') }
+
+    before do
+      generate_test_image(input_path, color: 'cmyk', cg_type: 'cmyk', profile: 'cmyk', bands: 4)
+    end
+
+    it 'creates an srgb jp2' do
+      expect(File).to exist input_path
+      expect(File).not_to exist jp2_output_file
+      expect(assembly_image.srgb?).to be false
+      expect(assembly_image.vips_image.interpretation).to eq :cmyk
+      expect(assembly_image.has_profile?).to be true
+      expect(result).to be_a_kind_of Assembly::Image
+      expect(result.path).to eq jp2_output_file
+      expect(jp2_output_file).to have_jp2_mimetype
+
+      # NOTE: we verify the CMYK has been converted to an SRGB JP2 correctly by using ruby-vips instead of exif,
+      #   since exif does not correctly identify the color space ... and we have to verify this on the *temporary tiff*
+      #  because the lipvips version available for circleci does not speak JP2
+      temp_tiff_path = jp2creator.send(:make_tmp_tiff)
+      tmp_tiff_image = Assembly::Image.new(temp_tiff_path)
+      expect(tmp_tiff_image.srgb?).to be true
+    end
+  end
+
   context 'when the input file is a JPEG' do
+    let(:input_path) { TEST_JPEG_INPUT_FILE }
+
     before do
       generate_test_image(TEST_JPEG_INPUT_FILE)
     end
-
-    let(:input_path) { TEST_JPEG_INPUT_FILE }
 
     it 'creates jp2 when given a JPEG' do
       expect(File).to exist TEST_JPEG_INPUT_FILE
@@ -49,13 +75,13 @@ RSpec.describe Assembly::Image::Jp2Creator do
       expect(jp2_output_file).to have_jp2_mimetype
 
       # Indicates a temp tiff was created.
-      expect(creator.tmp_tiff_path).not_to be_nil
-      expect(File).not_to exist creator.tmp_tiff_path
+      expect(jp2creator.tmp_tiff_path).not_to be_nil
+      expect(File).not_to exist jp2creator.tmp_tiff_path
     end
   end
 
   describe '#make_tmp_tiff' do
-    subject(:tiff_file) { creator.send(:make_tmp_tiff) }
+    subject(:tiff_file) { jp2creator.send(:make_tmp_tiff) }
 
     let(:input_path) { 'spec/test_data/color_rgb_srgb_rot90cw.tif' }
     let(:vips_output) { Vips::Image.new_from_file tiff_file }

--- a/spec/image_spec.rb
+++ b/spec/image_spec.rb
@@ -169,31 +169,6 @@ RSpec.describe Assembly::Image do
       end
     end
 
-    context 'when given a cmyk tif' do
-      let(:input_path) { File.join(TEST_INPUT_DIR, 'cmky.tif') }
-
-      before do
-        generate_test_image(input_path, color: 'cmyk', cg_type: 'cmyk', profile: 'cmyk', bands: 4)
-      end
-
-      it 'creates an srgb jp2', skip: 'Need to verify the color space is correct in jp2' do
-        expect(File).to exist input_path
-        expect(File).not_to exist jp2_output_file
-        expect(assembly_image.exif.samplesperpixel).to be 4
-        expect(assembly_image.exif.bitspersample).to eql '8 8 8 8'
-        expect(assembly_image).to be_a_valid_image
-        expect(assembly_image).to be_jp2able
-        expect(assembly_image).to have_color_profile
-        result = assembly_image.create_jp2(output: jp2_output_file)
-        expect(result).to be_a_kind_of described_class
-        expect(result.path).to eq jp2_output_file
-        expect(jp2_output_file).to have_jp2_mimetype
-        # note, we verify the CMYK has been converted to an SRGB JP2 correctly by using ruby-vips instead of exif, since exif does not correctly
-        #  identify the color space...note: this line current does not work in circleci, potentially due to libvips version differences
-        expect(Vips::Image.new_from_file(jp2_output_file).get_value('interpretation')).to eq :srgb
-      end
-    end
-
     context 'when the source image has no profile' do
       let(:input_path) { File.join(TEST_INPUT_DIR, 'no_profile.tif') }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #55 

Actually, CMYK images have been working since we switched to libvips, but now we have a test that proves it.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



