### PR TITLE
remove no-longer-applicable comment

### DIFF
--- a/lib/assembly-image/jp2_creator.rb
+++ b/lib/assembly-image/jp2_creator.rb
@@ -68,7 +68,6 @@ module Assembly
 
       def jp2_create_command(source_path:, output:)
         options = []
-        # TODO: Consider using ruby-vips to determine the colorspace instead of relying on exif (which is done below)
         options << '-jp2_space sRGB' if image.srgb?
         options += KDU_COMPRESS_DEFAULT_OPTIONS
         options << "Clayers=#{layers}"


### PR DESCRIPTION
## Why was this change made? 🤔

incorrect comments are confusing.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



