### PR TITLE
remove yard gem (unused)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,6 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
 
 PLATFORMS
   x86_64-darwin-19
@@ -112,7 +109,6 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   simplecov
-  yard
 
 BUNDLED WITH
    2.3.17

--- a/assembly-image.gemspec
+++ b/assembly-image.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'yard'
 end


### PR DESCRIPTION
## Why was this change made? 🤔

to my knowledge, we never need to generate the rdocs

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡



