### PR TITLE
Disable VIPS file cache.

### DIFF
--- a/lib/assembly/image.rb
+++ b/lib/assembly/image.rb
@@ -42,6 +42,8 @@ module Assembly
     end
 
     def vips_image
+      # Disable cache. Otherwise, Vips gets confused by files with the same filename.
+      Vips.cache_set_max_files(0)
       # autorot will only affect images that need rotation: https://www.libvips.org/API/current/libvips-conversion.html#vips-autorot
       @vips_image ||= Vips::Image.new_from_file(path).autorot
     end


### PR DESCRIPTION
## Why was this change made? 🤔
Address problems with VIPS creating identical tiffs from different pngs with same filename.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test) that do IMAGE ACCESSIONING*** (e.g. create_preassembly_image_spec) and/or test in [stage|qa] environment, in addition to specs. ⚡

Integration

